### PR TITLE
p-like-a css class 추가

### DIFF
--- a/static/css/blog.css
+++ b/static/css/blog.css
@@ -21,24 +21,24 @@ table, th, td {
     padding-right: 10px;
 }
 
-a {
-    color: black;
-}
-
-a:hover {
-    text-decoration: none;
-}
-
-a:link {
-    text-decoration: none;
-}
-
 /* General */
 .control-panel {
     border: #AAAAAA 1px solid;
     background: white;
     padding: 10px;
     margin-bottom: 10px;
+}
+
+.p-like-a a {
+    color: black;
+}
+
+.p-like-a a:hover {
+    text-decoration: none;
+}
+
+.p-like-a a:link {
+    text-decoration: none;
 }
 
 /* Main */

--- a/templates/blog/_tree.html
+++ b/templates/blog/_tree.html
@@ -4,7 +4,7 @@
 <script src="{% static 'js/tree.js' %}"></script>
 
 <div class="tree-wrapper">
-    <div class="list-group list-group-root">
+    <div class="list-group list-group-root p-like-a">
         {% recursetree pages %}
             <div class="list-group-item">
                 <div class="panel-title" style="margin-left: {% widthratio node.level 1 20 %}px;">

--- a/templates/blog/main.html
+++ b/templates/blog/main.html
@@ -27,7 +27,7 @@
                            class="btn btn-default">{% trans "Create" %}</a>
                     </div>
                 {% endif %}
-                <div class="main-current-list">
+                <div class="main-current-list p-like-a">
                     <h4>{% trans 'Currently changed' %}</h4>
                     {% for page in current_pages %}
                         <div class="main-current-page list-group-item">


### PR DESCRIPTION
list-group이나 여타 class명은 나중에 또 다른 이슈를 발생시킬 수 있다.
p-like-a라는 클래스를 따로 만들어서 명시하는 게 올바른 방향이다.

#41 을 해결한다